### PR TITLE
fix computation of inbox list

### DIFF
--- a/lib/wunderlist/api.rb
+++ b/lib/wunderlist/api.rb
@@ -70,7 +70,7 @@ module Wunderlist
     end
 
     def inbox
-      lists.to_a.first[1]
+      lists.values.detect { |list| list.inbox }
     end
 
     def tasks(list)


### PR DESCRIPTION
Old behaviour just took the first list item as inbox list. This was not the inbox list in my case
